### PR TITLE
Replace call to trim! with strip!

### DIFF
--- a/lib/datashift/populator.rb
+++ b/lib/datashift/populator.rb
@@ -51,7 +51,7 @@ module DataShift
       @current_value, @current_attribute_hash = value.to_s.split(Delimiters::attribute_list_start)
       
       if(@current_attribute_hash)
-        @current_attribute_hash.trim!
+        @current_attribute_hash.strip!
         puts "DEBUG: Populator Value contains additional attributes"
         @current_attribute_hash = nil unless @current_attribute_hash.include?('}')
       end


### PR DESCRIPTION
There was an errant call to trim! which doesn't exist in ruby. I believe what you meant was strip!. Regardless, I can't get image alt attributes to work, although an exception isn't thrown anymore when using them.
