### PR TITLE
Fix dependency order between DataShiftException and DataShift::Logging

### DIFF
--- a/lib/datashift.rb
+++ b/lib/datashift.rb
@@ -116,9 +116,9 @@ end
 
 DataShift::require_libraries
 
+require 'datashift/logging'
 require 'datashift/exceptions'
 require 'datashift/guards'
-require 'datashift/logging'
 require 'datashift/method_detail'
 require 'datashift/method_dictionary'
 require 'datashift/method_mapper'

--- a/lib/datashift/exceptions.rb
+++ b/lib/datashift/exceptions.rb
@@ -1,21 +1,22 @@
-# Copyright:: (c) Autotelik Media Ltd 2014 
+# Copyright:: (c) Autotelik Media Ltd 2014
 # Author ::   Tom Statter
 # Date ::     June 2014
 # License::   Free, Open Source.
 #
 
 module DataShift
-  
+
   class DataShiftException < StandardError
+    require 'datashift/logging'
     #
     include DataShift::Logging
-        
+
     def initialize( msg )
       super
       logger.error( msg)
     end
   end
-  
+
   class SaveError < DataShiftException
     def initialize( msg )
       super( msg )
@@ -27,12 +28,12 @@ module DataShift
       super( msg )
     end
   end
-  
+
   class BadRuby < StandardError; end
-  
+
   class UnsupportedFileType < StandardError; end
   class BadFile < StandardError; end
-  
+
   class MappingDefinitionError < StandardError; end
   class DataProcessingError < StandardError; end
 
@@ -40,11 +41,11 @@ module DataShift
   class MissingMandatoryError < StandardError; end
 
   class RecordNotFound < StandardError; end
-  
+
   class PathError < StandardError; end
-  
+
   class BadUri < StandardError; end
-   
+
   class CreateAttachmentFailed < StandardError; end
-  
+
 end


### PR DESCRIPTION
`bundle exec thor list datashift
WARNING: unable to load thorfile "...purelights.thor": uninitialized constant DataShift::Logging
.../bundler/gems/datashift-a95fb0763310/lib/datashift/exceptions.rb:11:in '<class:DataShiftException>'
No Thor commands available`

[Fixes #21]
