### PR TITLE
#40 - Fix for custom delimiter set for csv files

### DIFF
--- a/lib/datashift/column_packer.rb
+++ b/lib/datashift/column_packer.rb
@@ -23,9 +23,9 @@ module DataShift
     # TODO - better ways ?? - see transcoding and String#encode
 
     def escape_for_csv(value)
+      return nil if value.blank?
       text = value.to_s.gsub(text_delim, escape_text_delim()).gsub("\n", "\\n")
-
-      text = "#{text_delim}#{text}#{text_delim}" if(text.include?(Delimiters::csv_delim))
+      text = "#{text_delim}#{text}#{text_delim}" if(text.include?(Delimiters::csv_delim) && text.present?)
       text
     end
 

--- a/lib/exporters/csv_exporter.rb
+++ b/lib/exporters/csv_exporter.rb
@@ -23,7 +23,7 @@ module DataShift
     # Create CSV file from set of ActiveRecord objects
     # Options :
     # => :filename
-    # => :text_delim => Char to use to delim columns, useful when data contain embedded ','
+    # => :csv_delim => Char to use to delim columns, useful when data contain embedded ','
     # => ::methods => List of methods to additionally call on each record
     #
     def export(export_records, options = {})
@@ -39,12 +39,11 @@ module DataShift
 
       raise ArgumentError.new('Please supply set of ActiveRecord objects to export') unless(first.is_a?(ActiveRecord::Base))
 
-      Delimiters.text_delim = options[:text_delim] if(options[:text_delim])
+      Delimiters.csv_delim = options[:csv_delim] if(options[:csv_delim])
 
-      CSV.open( (options[:filename] || filename), "w" ) do |csv|
+      CSV.open( (options[:filename] || filename), "w", col_sep: Delimiters.csv_delim ) do |csv|
 
         csv.ar_to_headers( records )
-
         records.each do |r|
           next unless(r.is_a?(ActiveRecord::Base))
           csv.ar_to_csv(r, options)
@@ -58,7 +57,7 @@ module DataShift
     #
     def export_with_associations(klass, records, options = {})
 
-      Delimiters.text_delim = options[:text_delim] if(options[:text_delim])
+      Delimiters.csv_delim = options[:csv_delim] if(options[:csv_delim]) if(options[:csv_delim])
 
       MethodDictionary.find_operators( klass )
 
@@ -101,7 +100,6 @@ module DataShift
           csv << row # next record
         end
       end
-
     end
   end
 end

--- a/spec/csv_exporter_spec.rb
+++ b/spec/csv_exporter_spec.rb
@@ -23,12 +23,7 @@ describe 'CSV Exporter' do
     db_clear()    # todo read up about proper transactional fixtures
   end
 
-  context 'simple project' do
-
-    before(:each) do
-      create( :project )
-    end
-
+  describe '#initialize' do
     it "should be able to create a new CSV exporter" do
       exporter = DataShift::CsvExporter.new( 'exp_rspec_csv_empty.csv' )
 
@@ -40,26 +35,26 @@ describe 'CSV Exporter' do
 
       expect{ exporter.export([123.45]) }.to raise_error(ArgumentError)
     end
+  end
 
+  describe "#export" do
+    let(:project) { create( :project ) }
+    let(:expected_columns) { project.serializable_hash.keys }
+    let(:expected_values) { project.serializable_hash.values.map &:to_s }
+
+    before { project }
 
     it "should export collection of model objects to .xls file" do
-
-      expected = result_file('exp_project_collection_spec.csv')
-
-      exporter = DataShift::CsvExporter.new( expected )
-
-      count = Project.count
-
       Project.create( :value_as_string	=> 'Value as String', :value_as_boolean => true,	:value_as_double => 75.672)
 
+      expected = result_file('exp_project_collection_spec.csv')
+      exporter = DataShift::CsvExporter.new( expected )
+      count = Project.count
       Project.count.should == count + 1
-
       exporter.export(Project.all)
-
       expect(File.exists?(expected)).to eq true
 
       puts "Can manually check file @ #{expected}"
-
       File.foreach(expected) {}
       count = $.
       count.should == Project.count + 1
@@ -91,6 +86,32 @@ describe 'CSV Exporter' do
       puts "Can manually check file @ #{expected}"
     end
 
+    it "should export a model object to csv file with custom delimeter" do
+      expected = result_file('project_first_export_spec_with_custom_delimeter.csv')
+      exporter = DataShift::CsvExporter.new( expected )
+
+      exporter.export(Project.all[0])
+      got_columns, got_values = CSV.read(expected)
+      expect(expected_columns.count).to eq got_columns.count
+      expect(expected_values.count).to eq got_values.count
+
+      expect(expected_columns || got_columns).to eq expected_columns
+      expect(expected_values || got_values).to eq expected_values
+
+      exporter.export(Project.all[0], csv_delim: "§")
+      got_headers, got_columns = CSV.read(expected, col_sep: "§")
+
+      expect(expected_columns || got_columns).to eq expected_columns
+      expect(expected_values || got_values).to eq expected_values
+
+      exporter.export(Project.all[0], csv_delim: "£")
+      got_headers, got_columns = CSV.read(expected, col_sep: "£")
+
+      expect(expected_columns.count).to eq got_columns.count
+      expect(expected_columns || got_columns).to eq expected_columns
+      expect(expected_values || got_values).to eq expected_values
+    end
+
     it "should export a model and result of method calls on it to csv file" do
 
       expected = result_file('project_with_methods_export_spec.csv')
@@ -101,8 +122,6 @@ describe 'CSV Exporter' do
 
       expect(File.exists?(expected)).to eq true
 
-      puts "Can manually check file @ #{expected}"
-
       File.foreach(expected) {}
       count = $.
       count.should == Project.count + 1
@@ -110,35 +129,36 @@ describe 'CSV Exporter' do
 
   end
 
-  it "should export a model and associations to csv" do
+  describe "#export_with_assoiations" do
+    it "should export a model and associations to csv" do
 
-    create( :project_user )
-    create_list(:project, 7)
+      create( :project_user )
+      create_list(:project, 7)
 
-    expected = result_file('exp_project_plus_assoc_export_spec.csv')
+      expected = result_file('exp_project_plus_assoc_export_spec.csv')
 
-    gen = DataShift::CsvExporter.new(expected)
+      gen = DataShift::CsvExporter.new(expected)
 
-    items = Project.all
+      items = Project.all
 
-    gen.export_with_associations(Project, items)
+      gen.export_with_associations(Project, items)
 
-    File.foreach(expected) {}
-    count = $.
-    count.should == items.size + 1
+      File.foreach(expected) {}
+      count = $.
+      count.should == items.size + 1
 
-    expect(File.exists?(expected)).to eq true
+      expect(File.exists?(expected)).to eq true
 
-    csv = CSV.read(expected)
+      csv = CSV.read(expected)
 
-    expect(csv[0]).to include 'owner'
-    expect(csv[0]).to include 'user'
+      expect(csv[0]).to include 'owner'
+      expect(csv[0]).to include 'user'
 
-    user_inx = csv[0].index 'user'
+      user_inx = csv[0].index 'user'
 
-    expect(user_inx).to be > -1
+      expect(user_inx).to be > -1
 
-    expect( csv[1][user_inx] ).to include 'mr'
+      expect( csv[1][user_inx] ).to include 'mr'
+    end
   end
-
 end


### PR DESCRIPTION
- added rspec example to cover the problem
- refactored `csv_exporter_spec.rb` a bit to easly introduce autocomparing files. No need to manually look on files, but still there is need to refactor rest of file.
- added `return nil if value.blank?` in `column_packer.rb` to solve problem with badly escaped blank strings.
- replaced `:text_delim` with `:csv_delim` to fix issue with custom delimiters for csv files.