### PR TITLE
relax rubyzip dependency

### DIFF
--- a/datashift.gemspec
+++ b/datashift.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'paperclip', '~> 5.2', '>= 5.2.0'
   s.add_runtime_dependency 'spreadsheet', '~> 1.1'
 
-  s.add_runtime_dependency 'rubyzip', '~> 0.9', '>= 0.9.9'
+  s.add_runtime_dependency 'rubyzip', '>= 0.9.9'
 
   s.add_runtime_dependency 'thread_safe', '~> 0.3', '>= 0.3'
   s.add_runtime_dependency 'erubis', '~> 2.7', '>= 2.7.0'


### PR DESCRIPTION
I have a compatibility problem with `rubyzip` version required for this gem.

Since you are using pessimistic operator '~>'  it is locked in `0.9.9`, that is a version from more than 5 years ago.

Removing pessimistic operator allow use recent versions aside with older version `0.9.9`